### PR TITLE
Check Address api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/Qitmeer/qitmeer
 go 1.12
 
 require (
+	github.com/Qitmeer/crypto v0.0.0-20200516043559-dd457edff06c
 	github.com/davecgh/go-spew v1.1.1
 	github.com/dchest/blake256 v1.0.0
 	github.com/deckarep/golang-set v1.7.1

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/Qitmeer/qitmeer
 go 1.12
 
 require (
-	github.com/Qitmeer/crypto v0.0.0-20200516043559-dd457edff06c
 	github.com/davecgh/go-spew v1.1.1
 	github.com/dchest/blake256 v1.0.0
 	github.com/deckarep/golang-set v1.7.1

--- a/node/full.go
+++ b/node/full.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Qitmeer/qitmeer/params"
 	"github.com/Qitmeer/qitmeer/rpc"
 	"github.com/Qitmeer/qitmeer/services/acct"
+	"github.com/Qitmeer/qitmeer/services/address"
 	"github.com/Qitmeer/qitmeer/services/blkmgr"
 	"github.com/Qitmeer/qitmeer/services/common"
 	"github.com/Qitmeer/qitmeer/services/index"
@@ -37,6 +38,9 @@ type QitmeerFull struct {
 
 	// miner service
 	cpuMiner *miner.CPUMiner
+
+	// address service
+	addressApi *address.AddressApi
 
 	// clock time service
 	timeSource blockchain.MedianTimeSource
@@ -78,6 +82,7 @@ func (qm *QitmeerFull) Stop() error {
 
 func (qm *QitmeerFull) APIs() []rpc.API {
 	apis := qm.acctmanager.APIs()
+	apis = append(apis, qm.addressApi.APIs()...)
 	apis = append(apis, qm.cpuMiner.APIs()...)
 	apis = append(apis, qm.blockManager.API())
 	apis = append(apis, qm.txManager.APIs()...)
@@ -168,7 +173,8 @@ func newQitmeerFullNode(node *Node) (*QitmeerFull, error) {
 
 	qm.cpuMiner = miner.NewCPUMiner(cfg, node.Params, &policy, qm.sigCache,
 		qm.txManager.MemPool().(*mempool.TxPool), qm.timeSource, qm.blockManager, defaultNumWorkers)
-
+	// init address api
+	qm.addressApi = address.NewAddressApi(cfg, node.Params, qm.blockManager)
 	return &qm, nil
 }
 
@@ -180,6 +186,11 @@ func (qm *QitmeerFull) GetBlockManager() *blkmgr.BlockManager {
 // return cpu miner
 func (qm *QitmeerFull) GetCpuMiner() *miner.CPUMiner {
 	return qm.cpuMiner
+}
+
+// return address api
+func (qm *QitmeerFull) GetAddressApi() *address.AddressApi {
+	return qm.addressApi
 }
 
 // return peer server

--- a/node/full.go
+++ b/node/full.go
@@ -174,7 +174,7 @@ func newQitmeerFullNode(node *Node) (*QitmeerFull, error) {
 	qm.cpuMiner = miner.NewCPUMiner(cfg, node.Params, &policy, qm.sigCache,
 		qm.txManager.MemPool().(*mempool.TxPool), qm.timeSource, qm.blockManager, defaultNumWorkers)
 	// init address api
-	qm.addressApi = address.NewAddressApi(cfg, node.Params, qm.blockManager)
+	qm.addressApi = address.NewAddressApi(cfg, node.Params)
 	return &qm, nil
 }
 

--- a/services/address/api.go
+++ b/services/address/api.go
@@ -7,26 +7,23 @@ import (
 	"github.com/Qitmeer/qitmeer/config"
 	"github.com/Qitmeer/qitmeer/params"
 	"github.com/Qitmeer/qitmeer/rpc"
-	"github.com/Qitmeer/qitmeer/services/blkmgr"
 	"sync"
 )
 
 type AddressApi struct {
 	sync.Mutex
-	params       *params.Params
-	config       *config.Config
-	blockManager *blkmgr.BlockManager
+	params *params.Params
+	config *config.Config
 }
 
 type PublicAddressAPI struct {
 	addressApi *AddressApi
 }
 
-func NewAddressApi(cfg *config.Config, par *params.Params, blkMgr *blkmgr.BlockManager) *AddressApi {
+func NewAddressApi(cfg *config.Config, par *params.Params) *AddressApi {
 	return &AddressApi{
-		config:       cfg,
-		params:       par,
-		blockManager: blkMgr,
+		config: cfg,
+		params: par,
 	}
 }
 

--- a/services/address/api.go
+++ b/services/address/api.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2017-2018 The qitmeer developers
+
+package address
+
+import (
+	"github.com/Qitmeer/qitmeer/common/encode/base58"
+	"github.com/Qitmeer/qitmeer/config"
+	"github.com/Qitmeer/qitmeer/params"
+	"github.com/Qitmeer/qitmeer/rpc"
+	"github.com/Qitmeer/qitmeer/services/blkmgr"
+	"sync"
+)
+
+type AddressApi struct {
+	sync.Mutex
+	params       *params.Params
+	config       *config.Config
+	blockManager *blkmgr.BlockManager
+}
+
+type PublicAddressAPI struct {
+	addressApi *AddressApi
+}
+
+func NewAddressApi(cfg *config.Config, par *params.Params, blkMgr *blkmgr.BlockManager) *AddressApi {
+	return &AddressApi{
+		config:       cfg,
+		params:       par,
+		blockManager: blkMgr,
+	}
+}
+
+func NewPublicAddressAPI(ai *AddressApi) *PublicAddressAPI {
+	pmAPI := &PublicAddressAPI{addressApi: ai}
+	return pmAPI
+}
+
+func (c *AddressApi) APIs() []rpc.API {
+	return []rpc.API{
+		{
+			NameSpace: rpc.DefaultServiceNameSpace,
+			Service:   NewPublicAddressAPI(c),
+			Public:    true,
+		},
+	}
+}
+
+func (api *PublicAddressAPI) CheckAddress(address string, network string) (interface{}, error) {
+	_, ver, err := base58.QitmeerCheckDecode(address)
+	if err != nil {
+		return false, rpc.RpcInvalidError("Invalid address :" + err.Error())
+	}
+	var p *params.Params
+	switch network {
+	case "privnet":
+		p = &params.PrivNetParams
+	case "testnet":
+		p = &params.TestNetParams
+	case "mainnet":
+		p = &params.MainNetParams
+	case "mixnet":
+		p = &params.MixNetParams
+	default:
+		return false, rpc.RpcInvalidError("Invalid network : privnet | testnet | mainnet | mixnet")
+	}
+	if p.PubKeyHashAddrID != ver {
+		return false, rpc.RpcRuleError("address prefix error , need %s , actual: %s,network not match,please check it",
+			p.NetworkAddressPrefix, address[0:1])
+	}
+	return true, nil
+}


### PR DESCRIPTION
Fix Issue #264
```bash
curl -X POST \
  http://127.0.0.1:1234/ \
  -H 'authorization: Basic dGVzdDp0ZXN0' \
  -H 'cache-control: no-cache' \
  -H 'content-type: application/json' \
  -H 'postman-token: bcc778e4-cae3-62ac-b05f-e9d8ddd4f53f' \
  -d '{
  "method":"checkAddress",
  "version":"2.0",
  "params":["TmdynELSnV85MivyKsHWGjh3d6gSyDxjooD","testnet"], 
  "id":1
}'
```
right result 
```bash
{
    "jsonrpc": "2.0",
    "id": 1,
    "result": true
}
```
error
```bash
{
    "jsonrpc": "2.0",
    "id": 1,
    "error": {
        "code": -32000,
        "message": "Rule Error : address prefix error , need R , actual: T,network not match,please check it"
    }
}
```