### PR TITLE
bump up version to 0.9.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 
 EXECUTABLE := qitmeer
-GITVERSION := $(shell git rev-parse --short HEAD)
+GITVER := $(shell git rev-parse --short HEAD )
+GITDIRTY := $(shell git diff --quiet || echo '-dirty')
+GITVERSION = "$(GITVER)$(GITDIRTY)"
 DEV=dev
 RELEASE=release
 LDFLAG_DEV = -X github.com/Qitmeer/qitmeer/version.Build=$(DEV)-$(GITVERSION)

--- a/core/protocol/protocol.go
+++ b/core/protocol/protocol.go
@@ -16,7 +16,7 @@ const (
 	InitialProcotolVersion uint32 = 20
 
 	// ProtocolVersion is the latest protocol version this package supports.
-	ProtocolVersion uint32 = 21
+	ProtocolVersion uint32 = 22
 )
 
 // Network represents which qitmeer network a message belongs to.

--- a/version/version.go
+++ b/version/version.go
@@ -27,7 +27,7 @@ const (
 const (
 	Major uint = 0
 	Minor uint = 9
-	Patch uint = 1
+	Patch uint = 2
 )
 
 var (


### PR DESCRIPTION
and the make script supports to add dirty information automatically when build on a dirty repository.
ex:  a dirty build
```
qitmeer version 0.9.2+dev-2c72fec-dirty (Go version go1.14.4)
```
comparing with a clean build
```
qitmeer version 0.9.2+dev-5de22e0 (Go version go1.14.4))
```