### PR TITLE
Fix allocation-size-overflow issue and explicit string(int) conversion with rune

### DIFF
--- a/cmd/qx/qx_test.go
+++ b/cmd/qx/qx_test.go
@@ -74,8 +74,8 @@ func TestQitmeerBase58CheckEncode(t *testing.T) {
 		}
 	*/
 	for _, addrtest := range testAddresses {
-		encoded := base58.QitmeerCheckEncode(data, addrtest.ver[:])
-		assert.Equal(t, encoded, addrtest.addr)
+		encoded,_ := base58.QitmeerCheckEncode(data, addrtest.ver[:])
+		assert.Equal(t, string(encoded), addrtest.addr)
 	}
 }
 

--- a/common/encode/base58/base58.go
+++ b/common/encode/base58/base58.go
@@ -16,7 +16,7 @@ var bigRadix = big.NewInt(58)
 var bigZero = big.NewInt(0)
 
 // Decode decodes a modified base58 string to a byte slice.
-func Decode(b string) []byte {
+func Decode(b []byte) []byte {
 	answer := big.NewInt(0)
 	j := big.NewInt(1)
 
@@ -48,11 +48,15 @@ func Decode(b string) []byte {
 }
 
 // Encode encodes a byte slice to a modified base58 string.
-func Encode(b []byte) string {
+func Encode(b []byte) ([]byte, error) {
 	x := new(big.Int)
 	x.SetBytes(b)
 
-	answer := make([]byte, 0, len(b)*136/100)
+	input,err := checkInputOverflow(b)
+	if err != nil {
+		return nil,err
+	}
+	answer := make([]byte, 0, len(input)*136/100)
 	for x.Cmp(bigZero) > 0 {
 		mod := new(big.Int)
 		x.DivMod(x, bigRadix, mod)
@@ -73,5 +77,5 @@ func Encode(b []byte) string {
 		answer[i], answer[alen-1-i] = answer[alen-1-i], answer[i]
 	}
 
-	return string(answer)
+	return answer,nil
 }

--- a/common/encode/base58/base58_test.go
+++ b/common/encode/base58/base58_test.go
@@ -67,7 +67,7 @@ func TestBase58(t *testing.T) {
 	// Encode tests
 	for x, test := range stringTests {
 		tmp := []byte(test.in)
-		if res := base58.Encode(tmp); res != test.out {
+		if res,_ := base58.Encode(tmp); string(res) != test.out {
 			t.Errorf("Encode test #%d failed: got: %s want: %s",
 				x, res, test.out)
 			continue
@@ -81,7 +81,7 @@ func TestBase58(t *testing.T) {
 			t.Errorf("hex.DecodeString failed failed #%d: got: %s", x, test.in)
 			continue
 		}
-		if res := base58.Decode(test.out); !bytes.Equal(res, b) {
+		if res := base58.Decode([]byte(test.out)); !bytes.Equal(res, b) {
 			t.Errorf("Decode test #%d failed: got: %q want: %q",
 				x, res, test.in)
 			continue
@@ -90,7 +90,7 @@ func TestBase58(t *testing.T) {
 
 	// Decode with invalid input
 	for x, test := range invalidStringTests {
-		if res := base58.Decode(test.in); string(res) != test.out {
+		if res := base58.Decode([]byte(test.in)); string(res) != test.out {
 			t.Errorf("Decode invalidString test #%d failed: got: %q want: %q",
 				x, res, test.out)
 			continue

--- a/common/encode/base58/base58bench_test.go
+++ b/common/encode/base58/base58bench_test.go
@@ -27,7 +27,7 @@ func BenchmarkBase58Encode(b *testing.B) {
 func BenchmarkBase58Decode(b *testing.B) {
 	b.StopTimer()
 	data := bytes.Repeat([]byte{0xff}, 5000)
-	encoded := base58.Encode(data)
+	encoded,_ := base58.Encode(data)
 	b.SetBytes(int64(len(encoded)))
 	b.StartTimer()
 

--- a/common/encode/base58/base58check_test.go
+++ b/common/encode/base58/base58check_test.go
@@ -61,16 +61,16 @@ func TestBase58Check(t *testing.T) {
 		ver[0] = test.version0
 		ver[1] = test.version1
 		// test encoding
-		var eRes string
+		var eRes []byte
 		switch ver[0] {
 		case 0x42:
-			eRes = base58.BtcCheckEncode([]byte(test.in), ver[1])
+			eRes,_ = base58.BtcCheckEncode([]byte(test.in), ver[1])
 		case 0x44:
-			eRes = base58.DcrCheckEncode([]byte(test.in), ver)
+			eRes,_ = base58.DcrCheckEncode([]byte(test.in), ver)
 		default:
-			eRes = base58.QitmeerCheckEncode([]byte(test.in), ver[:])
+			eRes,_ = base58.QitmeerCheckEncode([]byte(test.in), ver[:])
 		}
-		if eRes != test.out {
+		if string(eRes) != test.out {
 			t.Errorf("CheckEncode test #%d failed: got %s, want: %s", x, eRes, test.out)
 		}
 		var res []byte

--- a/common/encode/base58/example_test.go
+++ b/common/encode/base58/example_test.go
@@ -15,7 +15,7 @@ import (
 // This example demonstrates how to decode modified base58 encoded data.
 func ExampleDecode() {
 	// Decode example modified base58 encoded data.
-	encoded := "25JnwSn7XKfNQ"
+	encoded := []byte("25JnwSn7XKfNQ")
 	decoded := base58.Decode(encoded)
 
 	// Show the decoded data.
@@ -30,10 +30,10 @@ func ExampleDecode() {
 func ExampleEncode() {
 	// Encode example data with the modified base58 encoding scheme.
 	data := []byte("Test data")
-	encoded := base58.Encode(data)
+	encoded,_ := base58.Encode(data)
 
 	// Show the encoded data.
-	fmt.Println("Encoded Data:", encoded)
+	fmt.Printf("Encoded Data: %s\n", encoded)
 
 	// Output:
 	// Encoded Data: 25JnwSn7XKfNQ
@@ -61,10 +61,10 @@ func ExampleCheckDecodeBtc() {
 func ExampleCheckEncodeBtc1() {
 	// Encode example data with the Base58Check encoding scheme.
 	data, _ := hex.DecodeString("62e907b15cbf27d5425399ebf6f0fb50ebb88f18a")
-	encoded := base58.BtcCheckEncode(data, 0x0)
+	encoded,_ := base58.BtcCheckEncode(data, 0x0)
 
 	// Show the encoded data.
-	fmt.Println("Encoded Data:", encoded)
+	fmt.Printf("Encoded Data: %s", encoded)
 
 	// Output:
 	// Encoded Data: 1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa
@@ -75,10 +75,10 @@ func ExampleCheckEncodeBtc1() {
 func ExampleCheckEncodeBtc() {
 	// Encode example data with the Base58Check encoding scheme.
 	data := []byte("Test data")
-	encoded := base58.BtcCheckEncode(data, 0x0)
+	encoded,_ := base58.BtcCheckEncode(data, 0x0)
 
 	// Show the encoded data.
-	fmt.Println("Encoded Data:", encoded)
+	fmt.Printf("Encoded Data: %s", encoded)
 
 	// Output:
 	// Encoded Data: 182iP79GRURMp7oMHDU
@@ -89,10 +89,10 @@ func ExampleCheckEncodeDcr() {
 	data := []byte("Test data")
 	ver := [2]byte{0x44, 0x0}
 
-	encoded := base58.DcrCheckEncode(data, ver)
+	encoded,_ := base58.DcrCheckEncode(data, ver)
 
 	// Show the encoded data.
-	fmt.Println("Encoded Data:", encoded)
+	fmt.Printf("Encoded Data: %s", encoded)
 
 	// Output:
 	// Encoded Data: 2uLtqkeVgFqTUBnjicK8o
@@ -134,11 +134,11 @@ func ExampleCheckEncode_addr() {
 
 	data, _ := hex.DecodeString("64e20eb6075561d30c23a517c5b73badbc120f05")
 	ver := [2]byte{0x0c, 0x40} //qitmeer main
-	encoded := base58.QitmeerCheckEncode(data, ver[:])
+	encoded,_ := base58.QitmeerCheckEncode(data, ver[:])
 	fmt.Println("Address (sha256) : Nm281BTkccPTDL1CfhAAR27GAzx2bqFLQx5")
-	fmt.Println("Address (b2b)    :", encoded)
-	encoded = base58.DcrCheckEncode(data, ver)
-	fmt.Println("Address (b256)   :", encoded)
+	fmt.Printf("Address (b2b)    : %s\n", encoded)
+	encoded,_ = base58.DcrCheckEncode(data, ver)
+	fmt.Printf("Address (b256)   : %s", encoded)
 	// Output:
 	// Address (sha256) : Nm281BTkccPTDL1CfhAAR27GAzx2bqFLQx5
 	// Address (b2b)    : Nm281BTkccPTDL1CfhAAR27GAzx2bnKjZdM
@@ -152,10 +152,10 @@ func ExampleCheckEncode() {
 	ver[0] = 0
 	ver[1] = 0
 
-	encoded := base58.QitmeerCheckEncode(data, ver[:])
+	encoded,_ := base58.QitmeerCheckEncode(data, ver[:])
 
 	// Show the encoded data.
-	fmt.Println("Encoded Data:", encoded)
+	fmt.Printf("Encoded Data: %s", encoded)
 
 	// Output:
 	// Encoded Data: 1182iP79GRURMp6Rsz9X

--- a/common/encode/bech32/bech32_test.go
+++ b/common/encode/bech32/bech32_test.go
@@ -294,13 +294,13 @@ func TestCoverage(t *testing.T) {
 	} else {
 		t.Log("Coverage Decode separator '1' at invalid position error case : ok / error :", err)
 	}
-	_, _, err = bech32.Decode("a" + string(32) + "1qqqqqq")
+	_, _, err = bech32.Decode("a" + string(rune(32)) + "1qqqqqq")
 	if err == nil {
 		t.Errorf("Coverage Decode invalid character human-readable part error case : FAIL")
 	} else {
 		t.Log("Coverage Decode invalid character human-readable part error case : ok / error :", err)
 	}
-	_, _, err = bech32.Decode("a" + string(127) + "1qqqqqq")
+	_, _, err = bech32.Decode("a" + string(rune(127)) + "1qqqqqq")
 	if err == nil {
 		t.Errorf("Coverage Decode invalid character human-readable part error case : FAIL")
 	} else {
@@ -353,7 +353,7 @@ func TestCoverage(t *testing.T) {
 	} else {
 		t.Log("Coverage Encode mix case error case : ok / error : ", err)
 	}
-	hrp = string(33) + string(126)
+	hrp = string(rune(33)) + string(rune(126))
 	data = make([]int, 90-7-len(hrp))
 	bech32String, err = bech32.Encode(hrp, data)
 	if err != nil {
@@ -361,7 +361,7 @@ func TestCoverage(t *testing.T) {
 	} else {
 		t.Log("Coverage Encode normal case : ok / bech32String : ", bech32String)
 	}
-	hrp = string(32) + "c"
+	hrp = string(rune(32)) + "c"
 	data = make([]int, 90-7-len(hrp))
 	bech32String, err = bech32.Encode(hrp, data)
 	if err == nil {
@@ -369,7 +369,7 @@ func TestCoverage(t *testing.T) {
 	} else {
 		t.Log("Coverage Encode invalid character human-readable part error case : ok / error : ", err)
 	}
-	hrp = "b" + string(127)
+	hrp = "b" + string(rune(127))
 	data = make([]int, 90-7-len(hrp))
 	bech32String, err = bech32.Encode(hrp, data)
 	if err == nil {
@@ -420,7 +420,7 @@ func TestBech32(t *testing.T) {
 		{"split1checkupstagehandshakeupstreamerranterredcaperred2y9e3w", true},
 		{"split1checkupstagehandshakeupstreamerranterredcaperred2y9e2w", false},                   // invalid checksum
 		{"s lit1checkupstagehandshakeupstreamerranterredcaperredp8hs2p", false},                   // invalid character (space) in hrp
-		{"spl" + string(127) + "t1checkupstagehandshakeupstreamerranterredcaperred2y9e3w", false}, // invalid character (DEL) in hrp
+		{"spl" + string(rune(127)) + "t1checkupstagehandshakeupstreamerranterredcaperred2y9e3w", false}, // invalid character (DEL) in hrp
 		{"split1cheo2y9e2w", false}, // invalid character (o) in data part
 		{"split1a2y9w", false},      // too short data part
 		{"1checkupstagehandshakeupstreamerranterredcaperred2y9e3w", false},                                     // empty hrp

--- a/core/address/address.go
+++ b/core/address/address.go
@@ -19,7 +19,8 @@ import (
 func encodeAddress(hash160 []byte, netID [2]byte) string {
 	// Format is 2 bytes for a network and address class (i.e. P2PKH vs
 	// P2SH), 20 bytes for a RIPEMD160 hash, and 4 bytes of checksum.
-	return base58.QitmeerCheckEncode(hash160[:ripemd160.Size], netID[:])
+	res,_ := base58.QitmeerCheckEncode(hash160[:ripemd160.Size], netID[:])
+	return string(res)
 }
 
 // encodePKAddress returns a human-readable payment address to a public key
@@ -54,7 +55,8 @@ func encodePKAddress(serializedPK []byte, netID [2]byte, algo ecc.EcType) string
 	}
 
 	pubKeyBytes = append(pubKeyBytes, compressed...)
-	return base58.QitmeerCheckEncode(pubKeyBytes, netID[:])
+	res,_ := base58.QitmeerCheckEncode(pubKeyBytes, netID[:])
+	return string(res)
 }
 
 // PubKeyHashAddress is an Address for a pay-to-pubkey-hash (P2PKH)

--- a/core/address/address_test.go
+++ b/core/address/address_test.go
@@ -248,10 +248,10 @@ func TestAddress(t *testing.T) {
 			var saddr []byte
 			switch d := decoded.(type) {
 			case *PubKeyHashAddress:
-				decoded := base58.Decode(encode)
+				decoded := base58.Decode([]byte(encode))
 				saddr = decoded[2 : 2+ripemd160.Size]
 			case *ScriptHashAddress:
-				decoded := base58.Decode(encode)
+				decoded := base58.Decode([]byte(encode))
 				saddr = decoded[2 : 2+ripemd160.Size]
 			case *SecpPubKeyAddress:
 				// Ignore the error here since the script

--- a/core/message/message.go
+++ b/core/message/message.go
@@ -192,7 +192,7 @@ func readMessageHeader(r io.Reader) (int, *messageHeader, error) {
 	s.ReadElements(hr, &hdr.magic, &command, &hdr.length, &hdr.checksum)
 
 	// Strip trailing zeros from command string.
-	hdr.command = string(bytes.TrimRight(command[:], string(0)))
+	hdr.command = string(bytes.TrimRight(command[:], string(rune(0))))
 
 	return n, &hdr, nil
 }

--- a/crypto/bip32/utils.go
+++ b/crypto/bip32/utils.go
@@ -88,11 +88,12 @@ func addChecksumToBytes(data []byte) ([]byte, error) {
 }
 
 func base58Encode(data []byte) string {
-	return base58.Encode(data)
+	enc,_ :=base58.Encode(data)
+	return string(enc)
 }
 
 func base58Decode(data string) ([]byte, error) {
-	result := base58.Decode(data)
+	result := base58.Decode([]byte(data))
 	return result, nil
 }
 

--- a/p2p/addmgr/addrmgr.go
+++ b/p2p/addmgr/addrmgr.go
@@ -563,7 +563,7 @@ func (a *AddrManager) addAddressByIP(addrIP string) error {
 	if ip == nil {
 		return fmt.Errorf("invalid ip address %s", addr)
 	}
-	port, err := strconv.ParseUint(portStr, 10, 0)
+	port, err := strconv.ParseUint(portStr, 10, 16)
 	if err != nil {
 		return fmt.Errorf("invalid port %s: %v", portStr, err)
 	}

--- a/p2p/connmgr/seed.go
+++ b/p2p/connmgr/seed.go
@@ -59,7 +59,7 @@ func SeedFromDNS(chainParams *params.Params, reqServices protocol.ServiceFlag, l
 			}
 			addresses := make([]*types.NetAddress, len(seedpeers))
 			// if this errors then we have *real* problems
-			intPort, _ := strconv.Atoi(chainParams.DefaultPort)
+			intPort, _ := strconv.ParseUint(chainParams.DefaultPort,10,16)
 			for i, peer := range seedpeers {
 				addresses[i] = types.NewNetAddressTimestamp(
 					// bitcoind seeds with addresses from

--- a/p2p/peerserver/upnp.go
+++ b/p2p/peerserver/upnp.go
@@ -229,7 +229,7 @@ func getServiceURL(rootURL string) (url string, err error) {
 	}
 	defer r.Body.Close()
 	if r.StatusCode >= 400 {
-		err = errors.New(string(r.StatusCode))
+		err = errors.New(string(rune(r.StatusCode)))
 		return
 	}
 	var root root

--- a/qx/handle_addr.go
+++ b/qx/handle_addr.go
@@ -34,8 +34,11 @@ func EcPubKeyToAddress(version string, pubkey string) (string, error) {
 	}
 	h := hash.Hash160(data)
 
-	address := base58.QitmeerCheckEncode(h, ver[:])
-	return address, nil
+	address,err := base58.QitmeerCheckEncode(h, ver[:])
+	if err!=nil {
+		return "",err
+	}
+	return string(address),nil
 }
 
 func EcScriptKeyToAddress(version string, pubkey string) (string, error) {
@@ -64,8 +67,11 @@ func EcScriptKeyToAddress(version string, pubkey string) (string, error) {
 	}
 	h := hash.Hash160(data)
 
-	address := base58.QitmeerCheckEncode(h, ver[:])
-	return address, nil
+	address,err := base58.QitmeerCheckEncode(h, ver[:])
+	if err != nil {
+		return "",err
+	}
+	return string(address), nil
 }
 
 func EcPubKeyToAddressSTDO(version []byte, pubkey string) {
@@ -75,6 +81,6 @@ func EcPubKeyToAddressSTDO(version []byte, pubkey string) {
 	}
 	h := hash.Hash160(data)
 
-	address := base58.QitmeerCheckEncode(h, version[:])
+	address,_ := base58.QitmeerCheckEncode(h, version[:])
 	fmt.Printf("%s\n", address)
 }

--- a/qx/handle_difficulty.go
+++ b/qx/handle_difficulty.go
@@ -92,7 +92,7 @@ func HashrateToCompact(difficulty string, blocktime int) {
 }
 
 func CompactToGPS(compactS string, blockTime, scale int, printDetail bool) {
-	compact, err := strconv.ParseUint(compactS, 10, 64)
+	compact, err := strconv.ParseUint(compactS, 10, 32)
 	if err != nil {
 		ErrExit(err)
 	}

--- a/qx/txflag.go
+++ b/qx/txflag.go
@@ -93,7 +93,7 @@ func (v *TxInputsFlag) Set(s string) error {
 		return fmt.Errorf("tx hash should be 32 bytes")
 	}
 
-	index, err := strconv.ParseUint(input[1], 10, 64)
+	index, err := strconv.ParseUint(input[1], 10, 32)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Size computation for allocation may overflow. 
- https://github.com/golang/go/issues/32479 warn about string(int) type conversions
- Incorrect conversion between integer types.  the converting `strconv.Atoi` and `strconv.ParseUint` to integer types of smaller bit size can produce unexpected value.