### PR TITLE
fix address data race in the `testutils`

### DIFF
--- a/testutils/testwallet.go
+++ b/testutils/testwallet.go
@@ -172,8 +172,12 @@ func (w *testWallet) newAddress() (types.Address, error) {
 	return addrx, nil
 }
 
-func (w *testWallet) NewAddress() (types.Address, error) {
-	return w.newAddress()
+// NewAddress return a new address from the wallet's key chain
+// which is safe for concurrent access
+func (m *testWallet) NewAddress() (types.Address, error) {
+	m.Lock()
+	defer m.Unlock()
+	return m.newAddress()
 }
 
 // convert the serialized private key into the p2pkh address

--- a/testutils/testwallet_test.go
+++ b/testutils/testwallet_test.go
@@ -47,7 +47,7 @@ func Test_newTestWallet(t *testing.T) {
 	if wallet.addrs[0].Encode() != expect.addr0 {
 		t.Errorf("hd key0 addr not matched, expect %v but got %v", wallet.addrs[0].Encode(), expect.addr0)
 	}
-	addr1, err := wallet.newAddress()
+	addr1, err := wallet.NewAddress()
 	if err != nil {
 		t.Errorf("failed get new address : %v", err)
 	}

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -65,7 +65,7 @@ func AssertBlockOrderAndHeight(t *testing.T, h *Harness, order, total, height ui
 
 // Spend amount from the wallet of the test harness and return tx hash
 func Spend(t *testing.T, h *Harness, amt types.Amount) (*hash.Hash, types.Address) {
-	addr, err := h.Wallet.newAddress()
+	addr, err := h.Wallet.NewAddress()
 	if err != nil {
 		t.Fatalf("failed to generate new address for test wallet: %v", err)
 	}


### PR DESCRIPTION
- This PR is only a easy fix for the `address[]`
- they are still a lot of data race remain unfixed,  please reproduce and see more errors by using `go test ./... -race`