### PR TITLE
P2P:Must support bidirectional channel for peer

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -90,6 +90,7 @@ type Config struct {
 	RelayNode      string   `long:"relaynode" description:"The address of relay node that routes traffic between two peers over a qitmeer “relay” peer."`
 	Whitelist      string   `long:"whitelist" description:"Add an IP network or IP that will not be banned. (eg. 192.168.1.0/24 or ::1)"`
 	Blacklist      []string `long:"blacklist" description:"Add some IP network or IP that will be banned. (eg. 192.168.1.0/24 or ::1)"`
+	LANPeers       []string `long:"lanpeers" description:"Add some peer by ID that will ignore dual channel mode detection"`
 }
 
 func (c *Config) GetMinningAddrs() []types.Address {

--- a/config/config.go
+++ b/config/config.go
@@ -88,9 +88,8 @@ type Config struct {
 	HostIP         string   `long:"externalip" description:"The IP address advertised by libp2p. This may be used to advertise an external IP."`
 	HostDNS        string   `long:"externaldns" description:"The DNS address advertised by libp2p. This may be used to advertise an external DNS."`
 	RelayNode      string   `long:"relaynode" description:"The address of relay node that routes traffic between two peers over a qitmeer “relay” peer."`
-	Whitelist      string   `long:"whitelist" description:"Add an IP network or IP that will not be banned. (eg. 192.168.1.0/24 or ::1)"`
+	Whitelist      []string `long:"whitelist" description:"Add an IP network or IP,PeerID that will not be banned or ignore dual channel mode detection. (eg. 192.168.1.0/24 or ::1 or [peer id])"`
 	Blacklist      []string `long:"blacklist" description:"Add some IP network or IP that will be banned. (eg. 192.168.1.0/24 or ::1)"`
-	LANPeers       []string `long:"lanpeers" description:"Add some peer by ID that will ignore dual channel mode detection"`
 }
 
 func (c *Config) GetMinningAddrs() []types.Address {

--- a/core/json/node.go
+++ b/core/json/node.go
@@ -49,6 +49,7 @@ type GetPeerInfoResult struct {
 	ConnTime   string               `json:"conntime,omitempty"`
 	Version    string               `json:"version,omitempty"`
 	Network    string               `json:"network,omitempty"`
+	Circuit    bool                 `json:"circuit,omitempty"`
 }
 
 // GetGraphStateResult data

--- a/core/protocol/protocol.go
+++ b/core/protocol/protocol.go
@@ -16,7 +16,7 @@ const (
 	InitialProcotolVersion uint32 = 32
 
 	// ProtocolVersion is the latest protocol version this package supports.
-	ProtocolVersion uint32 = 32
+	ProtocolVersion uint32 = 33
 )
 
 // Network represents which qitmeer network a message belongs to.

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/minio/highwayhash v1.0.0
 	github.com/multiformats/go-multiaddr v0.3.1
 	github.com/multiformats/go-multiaddr-net v0.2.0
+	github.com/multiformats/go-multistream v0.1.2
 	github.com/pkg/errors v0.9.1
 	github.com/prysmaticlabs/go-bitfield v0.0.0-20200618145306-2ae0807bef65
 	github.com/prysmaticlabs/go-ssz v0.0.0-20200101200214-e24db4d9e963

--- a/node/api.go
+++ b/node/api.go
@@ -199,6 +199,7 @@ func (api *PublicBlockChainAPI) GetPeerInfo(verbose *bool, network *string) (int
 			Address:   p.Address,
 			BytesSent: p.BytesSent,
 			BytesRecv: p.BytesRecv,
+			Circuit:   p.IsCircuit,
 		}
 		info.Protocol = p.Protocol
 		info.Services = p.Services.String()

--- a/p2p/common/config.go
+++ b/p2p/common/config.go
@@ -46,4 +46,5 @@ type Config struct {
 	Params         *params.Params
 	Banning        bool // Open or not ban module
 	DisableListen  bool
+	LANPeers       []string
 }

--- a/p2p/peers/statssnap.go
+++ b/p2p/peers/statssnap.go
@@ -30,6 +30,7 @@ type StatsSnap struct {
 	LastRecv   time.Time
 	BytesSent  uint64
 	BytesRecv  uint64
+	IsCircuit  bool
 }
 
 func (p *StatsSnap) IsRelay() bool {

--- a/p2p/service.go
+++ b/p2p/service.go
@@ -607,6 +607,7 @@ func NewService(cfg *config.Config, events *event.Feed, param *params.Params) (*
 			DenyListCIDR:         cfg.Blacklist,
 			Banning:              cfg.Banning,
 			DisableListen:        cfg.DisableListen,
+			LANPeers:             cfg.LANPeers,
 		},
 		ctx:           ctx,
 		cancel:        cancel,

--- a/p2p/service.go
+++ b/p2p/service.go
@@ -580,6 +580,18 @@ func NewService(cfg *config.Config, events *event.Feed, param *params.Params) (*
 		}
 	}
 
+	allowListCIDR := ""
+	lanPeers := []string{}
+
+	if len(cfg.Whitelist) > 0 {
+		for _, wl := range cfg.Whitelist {
+			if strings.Contains(wl, "/") {
+				allowListCIDR = wl
+			} else {
+				lanPeers = append(lanPeers, wl)
+			}
+		}
+	}
 	s := &Service{
 		cfg: &common.Config{
 			NoDiscovery:          cfg.NoDiscovery,
@@ -603,11 +615,11 @@ func NewService(cfg *config.Config, events *event.Feed, param *params.Params) (*
 			HostAddress:          cfg.HostIP,
 			HostDNS:              cfg.HostDNS,
 			RelayNodeAddr:        cfg.RelayNode,
-			AllowListCIDR:        cfg.Whitelist,
+			AllowListCIDR:        allowListCIDR,
 			DenyListCIDR:         cfg.Blacklist,
 			Banning:              cfg.Banning,
 			DisableListen:        cfg.DisableListen,
-			LANPeers:             cfg.LANPeers,
+			LANPeers:             lanPeers,
 		},
 		ctx:           ctx,
 		cancel:        cancel,
@@ -615,7 +627,6 @@ func NewService(cfg *config.Config, events *event.Feed, param *params.Params) (*
 		isPreGenesis:  true,
 		events:        events,
 	}
-
 	dv5Nodes := parseBootStrapAddrs(s.cfg.BootstrapNodeAddr)
 	s.cfg.Discv5BootStrapAddr = dv5Nodes
 

--- a/p2p/synch/chainstate.go
+++ b/p2p/synch/chainstate.go
@@ -109,6 +109,13 @@ func (s *Sync) chainStateHandler(ctx context.Context, msg interface{}, stream li
 		}
 		return ErrMessage(err)
 	}
+	if !s.bidirectionalChannelCapacity(pe, stream.Conn()) {
+		s.UpdateChainState(pe, m, false)
+		if err := s.EncodeResponseMsgPro(stream, s.getChainState(), common.ErrDAGConsensus); err != nil {
+			return err
+		}
+		return nil
+	}
 	s.UpdateChainState(pe, m, true)
 	return s.EncodeResponseMsg(stream, s.getChainState())
 }

--- a/p2p/synch/handshake.go
+++ b/p2p/synch/handshake.go
@@ -198,6 +198,12 @@ func (s *Sync) bidirectionalChannelCapacity(pe *peers.Peer, conn network.Conn) b
 			return true
 		}
 	}
+	_, ok := s.LANPeers[pe.GetID()]
+	if ok {
+		pe.SetBidChanCap(time.Time{})
+		return true
+	}
+	//
 	peAddr := conn.RemoteMultiaddr()
 	ipAddr := ""
 	protocol := ""

--- a/p2p/synch/sync.go
+++ b/p2p/synch/sync.go
@@ -7,7 +7,6 @@ package synch
 import (
 	"context"
 	"fmt"
-	"github.com/Qitmeer/qitmeer/core/blockdag"
 	"github.com/Qitmeer/qitmeer/p2p/common"
 	"github.com/Qitmeer/qitmeer/p2p/encoder"
 	"github.com/Qitmeer/qitmeer/p2p/peers"
@@ -84,7 +83,7 @@ type Sync struct {
 	peerSync     *PeerSync
 	p2p          common.P2P
 	PeerInterval time.Duration
-	LANPeers     map[peer.ID]blockdag.Empty
+	LANPeers     map[peer.ID]struct{}
 }
 
 func (s *Sync) Start() error {
@@ -254,7 +253,7 @@ func (s *Sync) EncodeResponseMsgPro(stream libp2pcore.Stream, msg interface{}, r
 func NewSync(p2p common.P2P) *Sync {
 	sy := &Sync{p2p: p2p, peers: peers.NewStatus(p2p),
 		PeerInterval: params.ActiveNetParams.TargetTimePerBlock * 2,
-		LANPeers:     map[peer.ID]blockdag.Empty{}}
+		LANPeers:     map[peer.ID]struct{}{}}
 	sy.peerSync = NewPeerSync(sy)
 
 	for _, pid := range p2p.Config().LANPeers {
@@ -263,7 +262,7 @@ func NewSync(p2p common.P2P) *Sync {
 			log.Warn(fmt.Sprintf("LANPeers configuration error:%s", pid))
 			continue
 		}
-		sy.LANPeers[peid] = blockdag.Empty{}
+		sy.LANPeers[peid] = struct{}{}
 	}
 	return sy
 }


### PR DESCRIPTION
To connect private qitmeer nodes in the LAN, you can use the configuration parameters: `--lanpeers=[Peer ID]`